### PR TITLE
Fix: Retain Current Session Time on Reset Timer Button in Pomodoro App

### DIFF
--- a/src/components/Pomodoro/PomodoroApp.jsx
+++ b/src/components/Pomodoro/PomodoroApp.jsx
@@ -33,7 +33,7 @@ export function PomodoroApp() {
 
   const handleResetClick = () => {
     setIsPlaying(false);
-    setTimer(focusTime * TIMES.MINUTES_IN_SECONDS);
+    setTimer(isFocusMode ? focusTime * TIMES.MINUTES_IN_SECONDS : breakTime * TIMES.MINUTES_IN_SECONDS);
   };
 
   const handleConfigClick = () => {


### PR DESCRIPTION
**Issue**
The reset timer button in the Pomodoro App is currently not behaving as expected. When activated during a break session, it reverts the timer to the focus session time instead of maintaining the current session time.

**Changes Made**
To address this issue, the following modification has been made in the code:
`setTimer(isFocusMode ? focusTime * TIMES.MINUTES_IN_SECONDS : breakTime * TIMES.MINUTES_IN_SECONDS);`

Previously, the timer was always set to the focus session time:
`setTimer(focusTime * TIMES.MINUTES_IN_SECONDS);`

Now, the timer is adjusted based on the current session type, ensuring that the reset button retains the time of the ongoing session.

**Testing**
The fix has been tested by following the steps provided in the original issue description:
- Toggle Mode to Break Session
- Start the session.
- Click on the reset timer button.
- Observe that the timer now correctly returns to the appropriate session time, maintaining the current session duration.

**Expected Behavior**
The reset timer button should retain the time of the current session when clicked, allowing users to reset the timer for the current focus or break session.

This fix aims to enhance the user experience and ensure the proper functioning of the reset timer button in the Pomodoro App.