### PR TITLE
fix: prevent intro name cutoff and mobile overflow #10

### DIFF
--- a/src/pages/Home/sections/Introduction.module.css
+++ b/src/pages/Home/sections/Introduction.module.css
@@ -1,11 +1,11 @@
 .intro {
   width: 100%;
-  height: 100vh;
+  min-height: 100vh;
   background: linear-gradient(to bottom, #0a0a0a, #0f1117);
   display: flex;
   align-items: center;
   justify-content: center;
-  padding: 0 2rem;
+  padding: clamp(72px, 12vh, 96px) 2rem 0;
 }
 
 .intro::before {
@@ -74,7 +74,7 @@
 
 .heading {
   font-family: var(--heading-font);
-  font-size: 2.75rem;
+  font-size: clamp(1.5rem, 6vw, 2.5rem);
   font-weight: 800;
   line-height: 1.2;
   color: var(--main-blue);
@@ -155,17 +155,9 @@
     text-align: center;
   }
 
-  .heading {
-    font-size: 2rem;
-  }
-
   .image {
     width: 200px;
     height: 200px;
-  }
-
-  .intro {
-    padding-top: 4rem;
   }
 }
 


### PR DESCRIPTION
## Summary

This pull request fixes layout issues in the introduction section, particularly on mobile devices. Previously, the heading was partially hidden behind the fixed header and the overall content overflowed the screen vertically. This update ensures the layout adapts responsively and maintains visual clarity.

---

## Key Changes

1. **Padding and Layout Responsiveness:**
   - Replaced static `padding-top: 4rem` inside a media query with `padding: clamp(72px, 12vh, 96px) 2rem 0` directly on `.intro` for consistent spacing across all screen sizes.
   - Switched from `height: 100vh` to `min-height: 100vh` on `.intro` to better support dynamic content.

2. **Responsive Typography:**
   - Updated `.heading` to use `font-size: clamp(1.5rem, 6vw, 2.5rem)` for smoother scaling on different viewports.

3. **Simplified Media Queries:**
   - Removed redundant padding logic in mobile media query to avoid conflicts with `clamp()` padding.

---

## Motivation
The previous layout caused the user’s name to appear behind the fixed header on smaller screens, and the vertical spacing was inconsistent across devices. These changes modernize the intro section and ensure reliable rendering on all screen sizes.
